### PR TITLE
Fix mesa extra branch name

### DIFF
--- a/io.github.accessory.minus_games_gui.yml
+++ b/io.github.accessory.minus_games_gui.yml
@@ -8,7 +8,8 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
 
 x-gl-version: &gl-version '1.4'
-x-gl-versions: &gl-versions 24.08;24.08-extra;1.4
+# Change to `25.08-extra` when 25.08 is out
+x-gl-versions: &gl-versions 24.08;24.08extra;1.4
 x-gl-merge-dirs: &gl-merge-dirs vulkan/icd.d;glvnd/egl_vendor.d;OpenCL/vendors;lib/dri;lib/d3d;vulkan/explicit_layer.d;vulkan/implicit_layer.d
 
 add-extensions:


### PR DESCRIPTION
Hi, due to a bug in the 24.08 runtime release, the branch name for the Mesa extra ref mistakenly changed to `24.08extra` instead of `24.08-extra`. Since it is already released for 3 months, we can't change it back to the correct branch `24.08-extra`, hence this temporary fix.

When updating to 25.08, please switch back to the expected pattern ie. `25.08-extra`, I'll open an issue as a reminder.