### PR TITLE
Fix extensions

### DIFF
--- a/io.github.accessory.minus_games_gui.yml
+++ b/io.github.accessory.minus_games_gui.yml
@@ -35,20 +35,21 @@ add-extensions:
     enable-if: active-gl-driver
     autoprune-unless: active-gl-driver
 
-  org.freedesktop.Platform.VAAPI.Intel:
+  org.freedesktop.Platform.VAAPI.Intel.i386:
+    directory: lib/i386-linux-gnu/dri/intel-vaapi-driver
     version: *runtime-version
-    directory: lib/dri/intel-vaapi-driver
+    versions: *runtime-version
     autodelete: false
     no-autodownload: true
-    download-if: active-gl-driver
-    enable-if: active-gl-driver
+    add-ld-path: lib
+    download-if: have-intel-gpu
+    autoprune-unless: have-intel-gpu
 
-  org.freedesktop.Platform.ffmpeg-full:
-    directory: lib/ffmpeg
-    add-ld-path: .
-    version: *runtime-version
-    no-autodownload: true
+  org.freedesktop.Platform.codecs_extra.i386:
+    directory: lib/i386-linux-gnu/codecs-extra
+    version: '25.08-extra'
     autodelete: false
+    add-ld-path: lib
 
   com.valvesoftware.Steam.CompatibilityTool:
     subdirectories: true
@@ -113,10 +114,11 @@ modules:
       - |
         set -e
         mkdir -p /app/bin
-        mkdir -p /app/lib/dri/intel-vaapi-driver
         mkdir -p /app/lib/i386-linux-gnu/GL
+        mkdir -p /app/lib/debug/lib/i386-linux-gnu/GL
+        mkdir -p /app/lib/i386-linux-gnu/dri/intel-vaapi-driver
+        mkdir -p /app/lib/i386-linux-gnu/codecs-extra
         install -Dm644 -t /app/etc ld.so.conf
-        mkdir -p /app/lib/ffmpeg
         mkdir -p /app/share/steam/compatibilitytools.d
         mkdir -p /app/utils /app/share/vulkan
         ln -srv /app/{utils/,}share/vulkan/explicit_layer.d


### PR DESCRIPTION
* ffmpeg-full is replaced by codecs-extra in 25.08. The x86-64 version is auto installed by runtime, added i386 to manifest

* replaced vaapi x86-64 with i386. The former is auto-installed by runtime.

* Added mountpoints for i386 debug extensions. Without them debug extensions were probably unusable.