### PR TITLE
Drop ffmpeg extension

### DIFF
--- a/io.github.accessory.minus_games_gui.yml
+++ b/io.github.accessory.minus_games_gui.yml
@@ -43,13 +43,6 @@ add-extensions:
     download-if: active-gl-driver
     enable-if: active-gl-driver
 
-  org.freedesktop.Platform.ffmpeg-full:
-    directory: lib/ffmpeg
-    add-ld-path: .
-    version: *runtime-version
-    no-autodownload: true
-    autodelete: false
-
   com.valvesoftware.Steam.CompatibilityTool:
     subdirectories: true
     directory: share/steam/compatibilitytools.d


### PR DESCRIPTION
> This is supposed to ship in Freedesktop SDK 25.08. The major change for app developers is that there is no longer any need to have something like 

Source: https://bbhtt.in/posts/closing-the-chapter-on-openh264/